### PR TITLE
Add PyGLM runtime smoke test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,11 @@ test:
     - glm
   commands:
     - pip check
+    - python run_test.py
   requires:
     - pip
+  files:
+    - run_test.py
 
 about:
   home: https://github.com/Zuzu-Typ/PyGLM

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,24 @@
+import math
+
+import glm
+
+
+def assert_close(actual, expected):
+    assert math.isclose(actual, expected, rel_tol=1e-7, abs_tol=1e-7), (
+        actual,
+        expected,
+    )
+
+
+vector = glm.vec3(1.0, 2.0, 2.0)
+assert_close(glm.length(vector), 3.0)
+
+translation = glm.translate(glm.mat4(1.0), glm.vec3(4.0, 5.0, 6.0))
+point = translation * glm.vec4(vector, 1.0)
+assert tuple(point) == (5.0, 7.0, 8.0, 1.0)
+
+rotation = glm.angleAxis(glm.radians(90.0), glm.vec3(0.0, 0.0, 1.0))
+rotated = rotation * glm.vec3(1.0, 0.0, 0.0)
+assert_close(rotated.x, 0.0)
+assert_close(rotated.y, 1.0)
+assert_close(rotated.z, 0.0)


### PR DESCRIPTION
## Summary
- Add a recipe-local runtime smoke test for installed PyGLM vector, matrix, and quaternion operations.
- Keep this test-only, with no build-number bump.

## Validation
- git diff --check
- conda-smithy recipe-lint --conda-forge recipe
- Isolated venv with pyglm==2.8.3: python recipe/run_test.py